### PR TITLE
Fix Slices with whitespace or umlaut in data field

### DIFF
--- a/application/controllers/IndexController.php
+++ b/application/controllers/IndexController.php
@@ -80,7 +80,7 @@ class IndexController extends Controller
         }
 
         foreach ($this->params->toArray() as $param) {
-            $cube->slice($param[0], $param[1]);
+            $cube->slice($param[0], urldecode($param[1]));
         }
 
         return $cube;


### PR DESCRIPTION
Fixes issue related to URL encoding (or in this case decoding) in `cubeFromParams($params)` function.