### PR TITLE
Fixing an error when mixing certain dimension together

### DIFF
--- a/library/Cube/Ido/IdoHostStatusCubeRenderer.php
+++ b/library/Cube/Ido/IdoHostStatusCubeRenderer.php
@@ -17,7 +17,7 @@ class IdoHostStatusCubeRenderer extends CubeRenderer
     {
         $htm = parent::renderDimensionLabel($name, $row);
 
-        if ($next = $this->cube->getDimensionAfter($name)) {
+        if ($next = $this->cube->getDimensionAfter($name) && isset($next->hosts_cnt)) {
             $htm .= ' <span class="sum">(' . $this->summaries->$next->hosts_cnt . ')</span>';
         }
 


### PR DESCRIPTION
Upon using Cube for the first time, I cam upon an issue immediately.
Whenever I was using two dimensions, the error:
```
Undefined property: stdClass::$mydimension
```

A quick search told me it was a standard php error:

https://stackoverflow.com/questions/8496855/undefined-property-stdclass

and it was resolved quickly. My commit fix the issue I was
experimenting.