### PR TITLE
Fix rollup syntax for PostgreSQL databases

### DIFF
--- a/library/Cube/DbCube.php
+++ b/library/Cube/DbCube.php
@@ -278,7 +278,7 @@ abstract class DbCube extends Cube
         );
 
         if ($this->isPgsql()) {
-            $select->group('ROLLUP (' . implode('), (', $dimensions) . ')');
+            $select->group('ROLLUP (' . implode(', ', $dimensions) . ')');
         } else {
             $select->group('(' . implode('), (', $dimensions) . ') WITH ROLLUP');
         }


### PR DESCRIPTION
This PR fixes a problem with the PostgreSQL rollup syntax. The current version produces errors like ``Undefined property: stdClass::$hrs_is_active`` if more than one dimension is selected. 

Issues #27 and #9 should be fixed by this PR