### PR TITLE
DimensionParams: Fix `explode(): Passing null to param #2 is deprecated`

### DIFF
--- a/library/Cube/DimensionParams.php
+++ b/library/Cube/DimensionParams.php
@@ -5,6 +5,7 @@
 namespace Icinga\Module\Cube;
 
 use Icinga\Web\Url;
+use ipl\Stdlib\Str;
 
 class DimensionParams
 {
@@ -36,7 +37,7 @@ class DimensionParams
     // For the controller: DimensionsParam::fromArray($this->params->shift('dimensions'))
     public static function fromString($dimensions)
     {
-        return static::fromArray(explode(',', $dimensions));
+        return static::fromArray(Str::trimSplit($dimensions));
     }
 
 

--- a/library/Cube/DimensionParams.php
+++ b/library/Cube/DimensionParams.php
@@ -19,7 +19,6 @@ class DimensionParams
      */
     protected $params;
 
-    // For the form: DimensionsParam::fromUrl($url)
     public static function fromUrl(Url $url)
     {
         return static::fromString($url->getParam('dimensions'));
@@ -34,12 +33,10 @@ class DimensionParams
         return $self;
     }
 
-    // For the controller: DimensionsParam::fromArray($this->params->shift('dimensions'))
     public static function fromString($dimensions)
     {
         return static::fromArray(Str::trimSplit($dimensions));
     }
-
 
     /**
      * @param $dimension


### PR DESCRIPTION
fixes #150 