### PR TITLE
SeveritySort: Remove undefined column `hosts(_unhandled)_unreachable` 

### DIFF
--- a/library/Cube/CubeRenderer/HostStatusCubeRenderer.php
+++ b/library/Cube/CubeRenderer/HostStatusCubeRenderer.php
@@ -131,13 +131,6 @@ class HostStatusCubeRenderer extends CubeRenderer
 
     protected function getSeveritySortColumns(): Generator
     {
-        $columns = ['down', 'unreachable'];
-        foreach ($columns as $column) {
-            yield "hosts_unhandled_$column";
-        }
-
-        foreach ($columns as $column) {
-            yield "hosts_$column";
-        }
+        yield from ['hosts_unhandled_down', 'hosts_down'];
     }
 }


### PR DESCRIPTION
Icingadb-web no longer has the unreachable state and the `Hoststatesummary` columns `hosts_unreachable_handled` and `hosts_unreachable_unhandled` are removed. (see: https://github.com/Icinga/icingadb-web/pull/803).
The unreachable column is merged as the following:

* hosts_down_handled = (down && (handled || ! reachable)
* hosts_down_unhandled = (down && ! handled && reachable)


fixes https://github.com/Icinga/icingaweb2-module-cube/issues/160